### PR TITLE
 design: todoItemUI 완성, feat: home, todoItem, addTodoItem 간 이동

### DIFF
--- a/choi/app/src/main/java/com/example/study_choi/AddTodoItem.kt
+++ b/choi/app/src/main/java/com/example/study_choi/AddTodoItem.kt
@@ -3,6 +3,8 @@ package com.example.study_choi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -10,6 +12,8 @@ import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -17,32 +21,53 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.example.study_choi.ui.theme.Study_choiTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AddTodoItem() {
+fun AddTodoItem(navController: NavHostController) {
     val titleTextState = remember { mutableStateOf("") }
 
-    Column(
-        modifier = Modifier.padding(20.dp),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
+    Column {
         androidx.compose.material3.TopAppBar (
             title = { Text("Todo List") },
             navigationIcon = {
-                IconButton(onClick = {  }) {
+                IconButton(onClick = { navController.popBackStack() }) {
                     Icon(Icons.Filled.ArrowBack, "Cancel")
                 }
             }
         )
+        Column(
+            modifier = Modifier
+                .padding(20.dp)
+                .fillMaxWidth(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
 
-        Spacer(modifier = Modifier.height(16.dp))
+            TextField(
+                label = { Text(text = "Title") },
+                value = titleTextState.value,
+                onValueChange = { titleTextState.value = it })
+        }
+    }
+}
 
-        TextField(
-            label = { Text(text = "Title") },
-            value = titleTextState.value,
-            onValueChange = { titleTextState.value = it })
+@Preview
+@Composable
+fun previewAddTodo() {
+    Study_choiTheme {
+        // A surface container using the 'background' color from the theme
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            AddTodoItem(navController = rememberNavController())
+        }
     }
 }

--- a/choi/app/src/main/java/com/example/study_choi/HomeUI.kt
+++ b/choi/app/src/main/java/com/example/study_choi/HomeUI.kt
@@ -1,8 +1,10 @@
 package com.example.study_choi
 
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -15,6 +17,8 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -24,10 +28,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.example.study_choi.ui.theme.Study_choiTheme
+
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TopAppBar() {
+fun TopAppBar(navController : NavHostController) {
     Column {
         androidx.compose.material3.TopAppBar (
             title = { Text("Todo List") },
@@ -38,7 +44,7 @@ fun TopAppBar() {
                 }
             },
             actions = {
-                IconButton(onClick = {  }) {
+                IconButton(onClick = { navController.navigate(AllUI.AddTodoItem.name) }) {
                     Icon(Icons.Filled.Add, "todo add")
                 }
             }
@@ -47,13 +53,14 @@ fun TopAppBar() {
 }
 
 @Composable
-fun itemCard(order: Int) {
+fun itemCard(order: Int, navController: NavHostController) {
     Card(
         Modifier
             .padding(12.dp)
             .border(width = 4.dp, color = Color.Black)
             .fillMaxWidth()
             .height(100.dp)
+            .clickable { navController.navigate(AllUI.TodoItem.name) }
     ) {
         Column(
             verticalArrangement = Arrangement.Center,
@@ -61,26 +68,21 @@ fun itemCard(order: Int) {
         ) {
             Text("list $order")
         }
-        /*
-        Box() {
-            Text("list $order")
-        }
-        */
     }
 }
 
-
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun Home(navController : NavHostController) {
 
     Column {
-        TopAppBar()
+        TopAppBar(navController = navController)
         // todo_list 항목들 리스트뷰로
         LazyColumn {
             itemsIndexed(
                 listOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
             ) {
-                _, item -> itemCard(order = item)
+                _, item -> itemCard(order = item, navController = navController)
             }
         }
     }
@@ -90,5 +92,13 @@ fun Home(navController : NavHostController) {
 @Composable
 @Preview
 fun previewHome() {
-    Home(rememberNavController())
+    Study_choiTheme {
+        // A surface container using the 'background' color from the theme
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            Home(navController = rememberNavController())
+        }
+    }
 }

--- a/choi/app/src/main/java/com/example/study_choi/LoginUI.kt
+++ b/choi/app/src/main/java/com/example/study_choi/LoginUI.kt
@@ -3,8 +3,8 @@ package com.example.study_choi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -13,6 +13,8 @@ import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -25,11 +27,13 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.example.study_choi.ui.theme.Study_choiTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -76,18 +80,18 @@ fun LogIn(navController : NavHostController) {
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        Row(
-            horizontalArrangement = Arrangement.End
-        ) {
-            ClickableText(
-                text = AnnotatedString("sign up"),
-                onClick = { navController.navigate(AllUI.SignUp.name) },
-                style = TextStyle(
-                    fontSize = 14.sp,
-                    fontFamily = FontFamily.Default
-                )
-            )
-        }
+        ClickableText(
+            text = AnnotatedString("sign up"),
+            onClick = { navController.navigate(AllUI.SignUp.name) },
+            style = TextStyle(
+                fontSize = 14.sp,
+                fontFamily = FontFamily.Default,
+                textAlign = TextAlign.End
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(0.dp, 0.dp, 32.dp, 0.dp)
+        )
     }
 
 }
@@ -95,5 +99,13 @@ fun LogIn(navController : NavHostController) {
 @Composable
 @Preview
 fun previewLog() {
-    LogIn(rememberNavController())
+    Study_choiTheme {
+        // A surface container using the 'background' color from the theme
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            LogIn(rememberNavController())
+        }
+    }
 }

--- a/choi/app/src/main/java/com/example/study_choi/MainActivity.kt
+++ b/choi/app/src/main/java/com/example/study_choi/MainActivity.kt
@@ -23,6 +23,7 @@ class MainActivity : ComponentActivity() {
                     color = MaterialTheme.colorScheme.background
                 ) {
                     MyAppNavHost()
+                    // Home(navController = rememberNavController())
                 }
             }
         }

--- a/choi/app/src/main/java/com/example/study_choi/MyAppNavHost.kt
+++ b/choi/app/src/main/java/com/example/study_choi/MyAppNavHost.kt
@@ -39,7 +39,7 @@ fun MyAppNavHost() {
 
         composable(AllUI.AddTodoItem.name) {
             AddTodoItem(
-
+                navController = navController
             )
         }
     }

--- a/choi/app/src/main/java/com/example/study_choi/SignUpUI.kt
+++ b/choi/app/src/main/java/com/example/study_choi/SignUpUI.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -11,6 +12,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
@@ -24,6 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
+import com.example.study_choi.ui.theme.Study_choiTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -84,5 +88,13 @@ fun SignUp(navController : NavHostController) {
 @Composable
 @Preview
 fun previewSign() {
-    SignUp(rememberNavController())
+    Study_choiTheme {
+        // A surface container using the 'background' color from the theme
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            SignUp(navController = rememberNavController())
+        }
+    }
 }

--- a/choi/app/src/main/java/com/example/study_choi/TodoItemUI.kt
+++ b/choi/app/src/main/java/com/example/study_choi/TodoItemUI.kt
@@ -1,65 +1,148 @@
 package com.example.study_choi
 
+import android.content.Context
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.example.study_choi.ui.theme.Study_choiTheme
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TodoItemTopAppBar() {
-    Column {
-        androidx.compose.material3.TopAppBar (
-            title = { Text("Todo List") },
-            navigationIcon = {
-                IconButton(onClick = {  }) {
-                    Icon(Icons.Filled.ArrowBack, "Menu")
-                }
+fun DropDownMenuSample(
+    context: Context,
+    dropdownMenuExpanded: Boolean,
+    onDismiss: () -> Unit
+) {
+    DropdownMenu(
+        expanded = dropdownMenuExpanded,
+        onDismissRequest = onDismiss,
+        offset = DpOffset(x = 0.dp, y = 0.dp)
+    ) {
+        DropdownMenuItem(
+            onClick = {
+                onDismiss()
             },
-            actions = {
-                IconButton(onClick = {  }) {
-                    Icon(Icons.Filled.MoreVert, "todo")
-                }
+            text = {
+                    Text(text = "수정")
+            }
+        )
+        DropdownMenuItem(
+            onClick = {
+                onDismiss()
+            },
+            text = {
+                Text(text = "삭제")
             }
         )
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TodoItemTopAppBar(navController: NavHostController) {
+    val context = LocalContext.current
+    var dropdownMenuExpanded by remember { mutableStateOf(false) }
+
+    androidx.compose.material3.TopAppBar(
+        title = {
+            Text("Todo List")
+        },
+        navigationIcon = {
+            IconButton(onClick = { navController.popBackStack() }) {
+                Icon(Icons.Filled.ArrowBack, "Menu")
+            }
+        },
+        actions = {
+            IconButton(onClick = {
+                dropdownMenuExpanded = true
+            }) {
+                Icon(Icons.Filled.MoreVert, "todoModifyDelete")
+            }
+
+            DropDownMenuSample(context, dropdownMenuExpanded) {
+                dropdownMenuExpanded = false
+            }
+        }
+    )
+}
+
 @Composable
 fun TodoItem(navController: NavHostController) {
+
     Column(
-        modifier = Modifier.padding(20.dp),
+        modifier = Modifier
+            .fillMaxWidth(),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        TodoItemTopAppBar()
+        TodoItemTopAppBar(navController)
 
         Spacer(modifier = Modifier.height(8.dp))
 
-        Text(text = "To do title", fontSize = 20.sp)
+        Text(text = "To do title", fontSize = 32.sp)
 
-        Row(horizontalArrangement = Arrangement.End) {
-            Text(text = "end date", fontSize = 10.sp)
-        }
+        Spacer(modifier = Modifier.height(8.dp))
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(0.dp, 0.dp, 8.dp, 0.dp),
+            text = "end date",
+            fontSize = 16.sp,
+            textAlign =  TextAlign.End
+        )
 
-        Text(text = "To do description", fontSize = 16.sp)
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp, 0.dp, 0.dp, 0.dp),
+            text = "To do description",
+            fontSize = 20.sp
+        )
     }
 }
 
+@Preview
+@Composable
+fun previewTodoItem() {
+    Study_choiTheme {
+        // A surface container using the 'background' color from the theme
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            TodoItem(navController = rememberNavController())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
todoItem UI 완성, home에서 todoItem, addTodoItem으로 이동 연결

## Describe your changes
TodoItem에 drop down menu(수정, 삭제 메뉴) 구현, text 재배치
Home에서 todo list item 클릭 시 TodoItem 이동, Add icon 클릭 시 AddTodoItem 이동

## Additional Job
LogIn에 signup clickable text 위치 조정